### PR TITLE
modified donate button in popup for closed hospital

### DIFF
--- a/src/components/cards/HospitalCard.tsx
+++ b/src/components/cards/HospitalCard.tsx
@@ -14,6 +14,7 @@ import "./HospitalCard.style.css";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
 import CancelRoundedIcon from "@mui/icons-material/CancelRounded";
 import { styled } from "@mui/material/styles";
+import { HospitalPopup } from "../HospitalPopup";
 
 const CustomCancelIconButton = styled(IconButton)({
   opacity: 0.9,
@@ -65,7 +66,10 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
               label={`${popupInfo?.hospitalInfo.city},${popupInfo?.hospitalInfo.state}`}
               sx={{
                 "& .MuiChip-icon": {
-                  color: "#92C65E",
+                  color:
+                    `${popupInfo?.hospitalInfo?.status}` !== "Closed"
+                      ? "#92C65E"
+                      : "#DB5757",
                   fontSize: "15px",
                 },
                 color: "#454545",
@@ -119,7 +123,7 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
           sx={{
             display: "flex",
             flexDirection: "row",
-            justifyContent: "space-between",
+            justifyContent: "center",
             width: "100%",
           }}
         >
@@ -129,11 +133,15 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
             sx={{
               backgroundColor: "black",
               marginTop: "8px",
-              width: "112px",
+              width:
+                `${popupInfo?.hospitalInfo?.status}` !== "Closed"
+                  ? "112px"
+                  : "300px",
               height: "26px",
               borderRadius: "10px",
               textTransform: "none",
               fontSize: "10px",
+              marginRight: "2px",
               "&:hover": {
                 backgroundColor: "transparent",
                 color: "#000",
@@ -142,25 +150,28 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
           >
             Learn more
           </Button>
-          <Button
-            variant="contained"
-            href="#"
-            sx={{
-              backgroundColor: "black",
-              marginTop: "8px",
-              width: "112px",
-              height: "26px",
-              borderRadius: "10px",
-              textTransform: "none",
-              fontSize: "10px",
-              "&:hover": {
-                backgroundColor: "transparent",
-                color: "#000",
-              },
-            }}
-          >
-            Donate
-          </Button>
+          {popupInfo?.hospitalInfo.status !== "Closed" && (
+            <Button
+              variant="contained"
+              href="#"
+              sx={{
+                backgroundColor: "black",
+                marginTop: "8px",
+                width: "112px",
+                height: "26px",
+                borderRadius: "10px",
+                textTransform: "none",
+                fontSize: "10px",
+                marginLeft: "2px",
+                "&:hover": {
+                  backgroundColor: "transparent",
+                  color: "#000",
+                },
+              }}
+            >
+              Donate
+            </Button>
+          )}
         </Box>
         <Box sx={{ marginBottom: "5px" }}>
           <Typography

--- a/src/components/cards/HospitalCard.tsx
+++ b/src/components/cards/HospitalCard.tsx
@@ -16,6 +16,7 @@ import CancelRoundedIcon from "@mui/icons-material/CancelRounded";
 import { styled } from "@mui/material/styles";
 
 import { isHospitalOpen } from "../../services/hospitalInfo/hospitalInfoService";
+import { OPEN_MARKER_COLOR, CLOSED_MARKER_COLOR } from "../../styles/theme";
 
 const CustomCancelIconButton = styled(IconButton)({
   opacity: 0.9,
@@ -50,7 +51,7 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
   onClose,
 }) => {
   const isOpen = isHospitalOpen(popupInfo?.hospitalInfo);
-  const markerColor = isOpen ? "#92C65E" : "#DB5757";
+  const markerColor = isOpen ? OPEN_MARKER_COLOR : CLOSED_MARKER_COLOR;
   const buttonWidth = isOpen ? "112px" : "300px";
 
   return (

--- a/src/components/cards/HospitalCard.tsx
+++ b/src/components/cards/HospitalCard.tsx
@@ -15,8 +15,8 @@ import LocationOnIcon from "@mui/icons-material/LocationOn";
 import CancelRoundedIcon from "@mui/icons-material/CancelRounded";
 import { styled } from "@mui/material/styles";
 
-import { isHospitalOpen } from "../../services/hospitalInfo/hospitalInfoService";
 import { OPEN_MARKER_COLOR, CLOSED_MARKER_COLOR } from "../../styles/theme";
+import { hospitalInfoService } from "../../services/hospitalInfo/hospitalInfoService";
 
 const CustomCancelIconButton = styled(IconButton)({
   opacity: 0.9,
@@ -50,7 +50,7 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
   images,
   onClose,
 }) => {
-  const isOpen = isHospitalOpen(popupInfo?.hospitalInfo);
+  const isOpen = hospitalInfoService.isHospitalOpen(popupInfo?.hospitalInfo);
   const markerColor = isOpen ? OPEN_MARKER_COLOR : CLOSED_MARKER_COLOR;
   const buttonWidth = isOpen ? "112px" : "300px";
 

--- a/src/components/cards/HospitalCard.tsx
+++ b/src/components/cards/HospitalCard.tsx
@@ -47,6 +47,10 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
   images,
   onClose,
 }) => {
+  const isOpen = popupInfo?.hospitalInfo?.status !== "Closed";
+  const markerColor = isOpen ? "#92C65E" : "#DB5757";
+  const buttonWidth = isOpen ? "112px" : "300px";
+
   return (
     <Card
       sx={{
@@ -65,10 +69,7 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
               label={`${popupInfo?.hospitalInfo.city},${popupInfo?.hospitalInfo.state}`}
               sx={{
                 "& .MuiChip-icon": {
-                  color:
-                    `${popupInfo?.hospitalInfo?.status}` !== "Closed"
-                      ? "#92C65E"
-                      : "#DB5757",
+                  color: markerColor,
                   fontSize: "15px",
                 },
                 color: "#454545",
@@ -132,10 +133,7 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
             sx={{
               backgroundColor: "black",
               marginTop: "8px",
-              width:
-                `${popupInfo?.hospitalInfo?.status}` !== "Closed"
-                  ? "112px"
-                  : "300px",
+              width: buttonWidth,
               height: "26px",
               borderRadius: "10px",
               textTransform: "none",
@@ -149,7 +147,7 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
           >
             Learn more
           </Button>
-          {popupInfo?.hospitalInfo.status !== "Closed" && (
+          {isOpen && (
             <Button
               variant="contained"
               href="#"

--- a/src/components/cards/HospitalCard.tsx
+++ b/src/components/cards/HospitalCard.tsx
@@ -14,7 +14,6 @@ import "./HospitalCard.style.css";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
 import CancelRoundedIcon from "@mui/icons-material/CancelRounded";
 import { styled } from "@mui/material/styles";
-import { HospitalPopup } from "../HospitalPopup";
 
 const CustomCancelIconButton = styled(IconButton)({
   opacity: 0.9,

--- a/src/components/cards/HospitalCard.tsx
+++ b/src/components/cards/HospitalCard.tsx
@@ -15,6 +15,8 @@ import LocationOnIcon from "@mui/icons-material/LocationOn";
 import CancelRoundedIcon from "@mui/icons-material/CancelRounded";
 import { styled } from "@mui/material/styles";
 
+import { isHospitalOpen } from "../../services/hospitalInfo/hospitalInfoService";
+
 const CustomCancelIconButton = styled(IconButton)({
   opacity: 0.9,
   border: "none",
@@ -47,7 +49,7 @@ export const HospitalCard: React.FC<HospitalCardProps> = ({
   images,
   onClose,
 }) => {
-  const isOpen = popupInfo?.hospitalInfo?.status !== "Closed";
+  const isOpen = isHospitalOpen(popupInfo?.hospitalInfo);
   const markerColor = isOpen ? "#92C65E" : "#DB5757";
   const buttonWidth = isOpen ? "112px" : "300px";
 

--- a/src/models/hospitalInfo.ts
+++ b/src/models/hospitalInfo.ts
@@ -1,18 +1,16 @@
 export type HospitalInfo = {
-    id: number;
-    name: string;
-    status: string;
-    type: string;
-    description: string;
-    year: number;
-    country: string;
-    state: string;
-    zip: string; 
-    city: string;
-    address: string;
-    longitude: number;
-    latitude: number;
-    hospitalPicture1: string[];
-    hospitalPicture2: string[];
-    hospitalPicture3: string[];
-}
+  id: number;
+  name: string;
+  status: string;
+  type: string;
+  description: string;
+  year: number;
+  country: string;
+  state: string;
+  zip: string;
+  city: string;
+  address: string;
+  longitude: number;
+  latitude: number;
+  hospitalPicture1: string[];
+};

--- a/src/services/generalInfo/generalInfoService.ts
+++ b/src/services/generalInfo/generalInfoService.ts
@@ -6,30 +6,25 @@ class GeneralInfoService {
     const TABLE = import.meta.env.VITE_AIRTABLE_TABLE_GENERAL_REFERENCE;
     const MAX_RECORDS = 100;
 
-    return airtableService
-      .getTableRecords(TABLE, MAX_RECORDS)
-      .then((records) => {
-        return records;
+    return airtableService.getTableRecords(TABLE, MAX_RECORDS).then((records) =>
+      records.map((r) => {
+        return {
+          id: `${r.fields["ID"]}`,
+          status: r.fields["Status"],
+          totalOpen: r.fields["Total $ Open"],
+          totalFunded: r.fields["Total $ Funded"],
+          corpPartner1Name: r.fields["Corp Partner 1 Name"],
+          corpPartner1Logo: r.fields["Corp Partner 1 Logo"],
+          corpPartner1Type: r.fields["Corp Partner 1 Type"],
+          corpPartner2Name: r.fields["Corp Partner 2 Name"],
+          corpPartner2Logo: r.fields["Corp Partner 2 Logo"],
+          corpPartner2Type: r.fields["Corp Partner 2 Type"],
+          corpPartner3Name: r.fields["Corp Partner 3 Name"],
+          corpPartner3Logo: r.fields["Corp Partner 3 Logo"],
+          corpPartner3Type: r.fields["Corp Partner 3 Type"],
+        } as GeneralInfo;
       })
-      .then((records) =>
-        records.map((r) => {
-          return {
-            id: `${r.fields["ID"]}`,
-            status: r.fields["Status"],
-            totalOpen: r.fields["Total $ Open"],
-            totalFunded: r.fields["Total $ Funded"],
-            corpPartner1Name: r.fields["Corp Partner 1 Name"],
-            corpPartner1Logo: r.fields["Corp Partner 1 Logo"],
-            corpPartner1Type: r.fields["Corp Partner 1 Type"],
-            corpPartner2Name: r.fields["Corp Partner 2 Name"],
-            corpPartner2Logo: r.fields["Corp Partner 2 Logo"],
-            corpPartner2Type: r.fields["Corp Partner 2 Type"],
-            corpPartner3Name: r.fields["Corp Partner 3 Name"],
-            corpPartner3Logo: r.fields["Corp Partner 3 Logo"],
-            corpPartner3Type: r.fields["Corp Partner 3 Type"],
-          } as GeneralInfo;
-        })
-      );
+    );
   }
 }
 

--- a/src/services/hospitalFunded/hospitalFundedService.ts
+++ b/src/services/hospitalFunded/hospitalFundedService.ts
@@ -6,28 +6,23 @@ class HospitalFundedService {
     const TABLE = import.meta.env.VITE_AIRTABLE_TABLE_HOSPITAL_FUNDED_REFERENCE;
     const MAX_RECORDS = 100;
 
-    return airtableService
-      .getTableRecords(TABLE, MAX_RECORDS)
-      .then((records) => {
-        return records;
+    return airtableService.getTableRecords(TABLE, MAX_RECORDS).then((records) =>
+      records.map((r) => {
+        return {
+          orderID: `${r.fields["Order ID"]}`,
+          equipmentShipped: r.fields["# Equipment Shipped"],
+          fundingCompleted: r.fields["$ Funding Completed"],
+          funders: r.fields["# Funders"],
+          corporateFunding: r.fields["$ Corporate Funding"],
+          thankYouNote: r.fields["Thank You Note"],
+          fundedPicture1: r.fields["Funded Picture 1"],
+          fundedPicture2: r.fields["Funded Picture 2"],
+          fundedPicture3: r.fields["Funded Picture 3"],
+          fundedPicture4: r.fields["Funded Picture 4"],
+          fundedPicture5: r.fields["Funded Picture 5"],
+        } as HospitalFunded;
       })
-      .then((records) =>
-        records.map((r) => {
-          return {
-            orderID: `${r.fields["Order ID"]}`,
-            equipmentShipped: r.fields["# Equipment Shipped"],
-            fundingCompleted: r.fields["$ Funding Completed"],
-            funders: r.fields["# Funders"],
-            corporateFunding: r.fields["$ Corporate Funding"],
-            thankYouNote: r.fields["Thank You Note"],
-            fundedPicture1: r.fields["Funded Picture 1"],
-            fundedPicture2: r.fields["Funded Picture 2"],
-            fundedPicture3: r.fields["Funded Picture 3"],
-            fundedPicture4: r.fields["Funded Picture 4"],
-            fundedPicture5: r.fields["Funded Picture 5"],
-          } as HospitalFunded;
-        })
-      );
+    );
   }
 }
 

--- a/src/services/hospitalInfo/hospitalInfoService.test.ts
+++ b/src/services/hospitalInfo/hospitalInfoService.test.ts
@@ -19,9 +19,7 @@ describe("HospitalInfoService tests", () => {
           Address: "Type 2",
           Longitude: 1,
           Latitude: 1,
-          "Hospital Picture 1": "pic1.com",
-          "Hospital Picture 2": "pic2.com",
-          "Hospital Picture 3": "pic3.com",
+          "Hospital Picture 1": [{ url: "pic1.com" }],
           ID: 1,
         },
       },
@@ -45,11 +43,57 @@ describe("HospitalInfoService tests", () => {
         address: "Type 2",
         longitude: 1,
         latitude: 1,
-        hospitalPicture1: "pic1.com",
-        hospitalPicture2: "pic2.com",
-        hospitalPicture3: "pic3.com",
+        hospitalPicture1: ["pic1.com"],
         id: 1,
       },
     ]);
+  });
+  it("should return true if hospital status is Open", () => {
+    const mockHospitalInfo = {
+      id: 1,
+      name: "May Hospital",
+      status: "Open",
+      type: "A Organization",
+      description: "A Organization",
+      year: 2024,
+      country: "US",
+      state: "WA",
+      zip: "ZIP12345",
+      city: "Seattle",
+      address: "Type 2",
+      longitude: 1,
+      latitude: 1,
+      hospitalPicture1: ["pic1.com"],
+    };
+    const result = hospitalInfoService.isHospitalOpen(mockHospitalInfo);
+    expect(result).toBeTruthy();
+  });
+
+  it("should return true if hospital status is Closed", () => {
+    const mockHospitalInfo = {
+      id: 1,
+      name: "May Hospital",
+      status: "Closed",
+      type: "A Organization",
+      description: "A Organization",
+      year: 2024,
+      country: "US",
+      state: "WA",
+      zip: "ZIP12345",
+      city: "Seattle",
+      address: "Type 2",
+      longitude: 1,
+      latitude: 1,
+      hospitalPicture1: ["pic1.com"],
+    };
+    const result = hospitalInfoService.isHospitalOpen(mockHospitalInfo);
+    expect(result).toBeFalsy();
+  });
+
+  it("should throw error if hospital status is undefined", () => {
+    const mockHospitalInfo = undefined;
+    expect(() => {
+      hospitalInfoService.isHospitalOpen(mockHospitalInfo);
+    }).toThrow("hospitalInfo is undefined");
   });
 });

--- a/src/services/hospitalInfo/hospitalInfoService.ts
+++ b/src/services/hospitalInfo/hospitalInfoService.ts
@@ -64,6 +64,6 @@ class MockHospitalInfoService extends HospitalInfoService {
   }
 }
 
-const hospitalInfoService = new HospitalInfoService();
-// const hospitalInfoService = new MockHospitalInfoService();
+// const hospitalInfoService = new HospitalInfoService();
+const hospitalInfoService = new MockHospitalInfoService();
 export { hospitalInfoService, HospitalInfoService };

--- a/src/services/hospitalInfo/hospitalInfoService.ts
+++ b/src/services/hospitalInfo/hospitalInfoService.ts
@@ -7,7 +7,41 @@ const extractUrls = (attachments: any) => {
   return attachments ? attachments.map((att: any) => att.url) : [];
 };
 
-class MockHospitalInfoService {
+class HospitalInfoService {
+  isHospitalOpen = (hospitalInfo: HospitalInfo | undefined) => {
+    if (hospitalInfo === undefined) {
+      throw new Error("hospitalInfo is undefined");
+    } else {
+      return hospitalInfo.status !== "Closed";
+    }
+  };
+  async getHospitalInfo(): Promise<HospitalInfo[]> {
+    const TABLE = import.meta.env.VITE_AIRTABLE_TABLE_HOSPITAL_REFERENCE;
+    const MAX_RECORDS = 100;
+
+    return airtableService.getTableRecords(TABLE, MAX_RECORDS).then((records) =>
+      records.map((r) => {
+        return {
+          name: `${r.fields["Hospital Name"]}`,
+          status: r.fields["Status"],
+          type: r.fields["Type of Organization"],
+          description: r.fields["Organization Notes / Description"],
+          year: r.fields["Kids Served / Year"],
+          country: r.fields["Country"],
+          state: r.fields["State"],
+          zip: r.fields["ZIP"],
+          city: r.fields["City"],
+          address: r.fields["Address"],
+          longitude: r.fields["Longitude"],
+          latitude: r.fields["Latitude"],
+          hospitalPicture1: extractUrls(r.fields["Hospital Picture 1"]),
+          id: r.fields["ID"],
+        } as HospitalInfo;
+      })
+    );
+  }
+}
+class MockHospitalInfoService extends HospitalInfoService {
   async getHospitalInfo(): Promise<HospitalInfo[]> {
     return thumbnailData.map((data) => {
       return {
@@ -25,56 +59,11 @@ class MockHospitalInfoService {
         longitude: data["Longitude"],
         latitude: data["Latitude"],
         hospitalPicture1: extractUrls(data["Hospital Picture 1"]),
-        hospitalPicture2: extractUrls(data["Hospital Picture 1"]),
-        hospitalPicture3: extractUrls(data["Hospital Picture 1"]),
       } as HospitalInfo;
     });
   }
 }
 
-class HospitalInfoService {
-  async getHospitalInfo(): Promise<HospitalInfo[]> {
-    const TABLE = import.meta.env.VITE_AIRTABLE_TABLE_HOSPITAL_REFERENCE;
-    const MAX_RECORDS = 100;
-
-    return airtableService
-      .getTableRecords(TABLE, MAX_RECORDS)
-      .then((records) => {
-        return records;
-      })
-      .then((records) =>
-        records.map((r) => {
-          return {
-            name: `${r.fields["Hospital Name"]}`,
-            status: r.fields["Status"],
-            type: r.fields["Type of Organization"],
-            description: r.fields["Organization Notes / Description"],
-            year: r.fields["Kids Served / Year"],
-            country: r.fields["Country"],
-            state: r.fields["State"],
-            zip: r.fields["ZIP"],
-            city: r.fields["City"],
-            address: r.fields["Address"],
-            longitude: r.fields["Longitude"],
-            latitude: r.fields["Latitude"],
-            hospitalPicture1: extractUrls(r.fields["Hospital Picture 1"]),
-            hospitalPicture2: extractUrls(r.fields["Hospital Picture 2"]),
-            hospitalPicture3: extractUrls(r.fields["Hospital Picture 3"]),
-            id: r.fields["ID"],
-          } as HospitalInfo;
-        })
-      );
-  }
-}
-
-function isHospitalOpen(hospitalInfo: HospitalInfo | undefined) {
-  if (hospitalInfo === undefined) {
-    throw new Error("hospitalInfo is undefined");
-  } else {
-    return hospitalInfo.status !== "Closed";
-  }
-}
-
-// const hospitalInfoService = new HospitalInfoService();
-const hospitalInfoService = new MockHospitalInfoService();
-export { hospitalInfoService, HospitalInfoService, isHospitalOpen };
+const hospitalInfoService = new HospitalInfoService();
+// const hospitalInfoService = new MockHospitalInfoService();
+export { hospitalInfoService, HospitalInfoService };

--- a/src/services/hospitalInfo/hospitalInfoService.ts
+++ b/src/services/hospitalInfo/hospitalInfoService.ts
@@ -67,6 +67,14 @@ class HospitalInfoService {
   }
 }
 
+function isHospitalOpen(hospitalInfo: HospitalInfo | undefined) {
+  if (hospitalInfo === undefined) {
+    throw new Error("hospitalInfo is undefined");
+  } else {
+    return hospitalInfo.status !== "Closed";
+  }
+}
+
 // const hospitalInfoService = new HospitalInfoService();
 const hospitalInfoService = new MockHospitalInfoService();
-export { hospitalInfoService, HospitalInfoService };
+export { hospitalInfoService, HospitalInfoService, isHospitalOpen };

--- a/src/services/hospitalRequest/hospitalRequestService.test.ts
+++ b/src/services/hospitalRequest/hospitalRequestService.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
-import { airtableService } from '../../mapping/airtableService';
-import { hospitalRequestService } from './hospitalRequestService';
+import { describe, expect, it, vi } from "vitest";
+import { airtableService } from "../../mapping/airtableService";
+import { hospitalRequestService } from "./hospitalRequestService";
 
-describe('HospitalRequestService tests', () => {
-  it('getHospitalRequest', async () => {
+describe("HospitalRequestService tests", () => {
+  it("getHospitalRequest", async () => {
     const mockRecords = [
       {
         fields: {
@@ -30,8 +30,9 @@ describe('HospitalRequestService tests', () => {
         },
       },
     ];
-
-    const getTableRecordsSpy = vi.spyOn(airtableService, 'getTableRecords').mockResolvedValue(mockRecords as any);
+    const getTableRecordsSpy = vi
+      .spyOn(airtableService, "getTableRecords")
+      .mockResolvedValue(mockRecords as any);
 
     const result = await hospitalRequestService.getHospitalRequest();
 
@@ -39,26 +40,26 @@ describe('HospitalRequestService tests', () => {
 
     expect(result).toEqual([
       {
-        oppReqId: 'REQ12345',
-        name: 'May\'s Hospital',
-        requestNarrative: 'Request for new equipment',
+        oppReqId: "REQ12345",
+        name: "May's Hospital",
+        requestNarrative: "Request for new equipment",
         equipReq: 10,
         requested: 5000,
         kids3Y: 300,
         play3Y: 200,
         collected: 4000,
         funders: 5,
-        requestPicture1: 'pic1.jpg',
-        requestPicture2: 'pic2.jpg',
-        requestPicture3: 'pic3.jpg',
-        requestPicture4: 'pic4.jpg',
-        requestPicture5: 'pic5.jpg',
-        corpPartner1Name: 'Partner 1',
-        corpPartner1Logo: 'logo1.png',
-        corpPartner1Type: 'Type 1',
-        corpPartner2Name: 'Partner 2',
-        corpPartner2Logo: 'logo2.png',
-        corpPartner2Type: 'Type 2',
+        requestPicture1: "pic1.jpg",
+        requestPicture2: "pic2.jpg",
+        requestPicture3: "pic3.jpg",
+        requestPicture4: "pic4.jpg",
+        requestPicture5: "pic5.jpg",
+        corpPartner1Name: "Partner 1",
+        corpPartner1Logo: "logo1.png",
+        corpPartner1Type: "Type 1",
+        corpPartner2Name: "Partner 2",
+        corpPartner2Logo: "logo2.png",
+        corpPartner2Type: "Type 2",
       },
     ]);
   });

--- a/src/services/hospitalRequest/hospitalRequestService.ts
+++ b/src/services/hospitalRequest/hospitalRequestService.ts
@@ -7,40 +7,35 @@ class HospitalRequestService {
       .VITE_AIRTABLE_TABLE_HOSPITAL_REQUEST_REFERENCE;
     const MAX_RECORDS = 100;
 
-    return airtableService
-      .getTableRecords(TABLE, MAX_RECORDS)
-      .then((records) => {
-        return records;
+    return airtableService.getTableRecords(TABLE, MAX_RECORDS).then((records) =>
+      records.map((r) => {
+        return {
+          oppReqId: `${r.fields["Opportunities/Requests ID"]}`,
+          name: r.fields["Hospital Name (LInked)"],
+          requestNarrative: r.fields["Request Narrative"],
+          equipReq:
+            r.fields[
+              "# Equipment Requested (TBD if we show single brands + extras)"
+            ],
+          requested: r.fields["$ Requested"],
+          kids3Y: r.fields["Kids 3Y"],
+          play3Y: r.fields["Play 3Y"],
+          collected: r.fields["$ Collected"],
+          funders: r.fields["# Funders"],
+          requestPicture1: r.fields["Request Picture 1"],
+          requestPicture2: r.fields["Request Picture 2"],
+          requestPicture3: r.fields["Request Picture 3"],
+          requestPicture4: r.fields["Request Picture 4"],
+          requestPicture5: r.fields["Request Picture 5"],
+          corpPartner1Name: r.fields["Corp Partner 1 Name"],
+          corpPartner1Logo: r.fields["Corp Partner 1 Logo"],
+          corpPartner1Type: r.fields["Corp Partner 1 Type"],
+          corpPartner2Name: r.fields["Corp Partner 2 Name"],
+          corpPartner2Logo: r.fields["Corp Partner 2 Logo"],
+          corpPartner2Type: r.fields["Corp Partner 2 Type"],
+        } as HospitalRequest;
       })
-      .then((records) =>
-        records.map((r) => {
-          return {
-            oppReqId: `${r.fields["Opportunities/Requests ID"]}`,
-            name: r.fields["Hospital Name (LInked)"],
-            requestNarrative: r.fields["Request Narrative"],
-            equipReq:
-              r.fields[
-                "# Equipment Requested (TBD if we show single brands + extras)"
-              ],
-            requested: r.fields["$ Requested"],
-            kids3Y: r.fields["Kids 3Y"],
-            play3Y: r.fields["Play 3Y"],
-            collected: r.fields["$ Collected"],
-            funders: r.fields["# Funders"],
-            requestPicture1: r.fields["Request Picture 1"],
-            requestPicture2: r.fields["Request Picture 2"],
-            requestPicture3: r.fields["Request Picture 3"],
-            requestPicture4: r.fields["Request Picture 4"],
-            requestPicture5: r.fields["Request Picture 5"],
-            corpPartner1Name: r.fields["Corp Partner 1 Name"],
-            corpPartner1Logo: r.fields["Corp Partner 1 Logo"],
-            corpPartner1Type: r.fields["Corp Partner 1 Type"],
-            corpPartner2Name: r.fields["Corp Partner 2 Name"],
-            corpPartner2Logo: r.fields["Corp Partner 2 Logo"],
-            corpPartner2Type: r.fields["Corp Partner 2 Type"],
-          } as HospitalRequest;
-        })
-      );
+    );
   }
 }
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,2 @@
+export const OPEN_MARKER_COLOR = "#92C65E";
+export const CLOSED_MARKER_COLOR = "#DB5757";


### PR DESCRIPTION
## Description
- Following our discussion in the last meeting, I’ve **removed the Donate button from the popup for the closed hospital**. 
- Additionally, just in case, I adjusted **the color of the marker in the location chip based on the hospital's status** ('Closed' or 'Actively funding'). If you'd prefer to revert to the previous green color, please let me know. :)

![Screenshot 2024-08-19 at 11 47 32 PM](https://github.com/user-attachments/assets/1bce6ed1-0422-46d1-8c69-d834f0f069ff)


- Code sections where the **marker chip color** to the left of the address changes **based on the hospital's status**.  
<img width="736" alt="Screenshot 2024-08-20 at 12 06 12 AM" src="https://github.com/user-attachments/assets/181465da-36c8-42c6-b5d0-13f279150243">

<br>
<br>




- Code sections where the presence of the **Donate button** is toggled **based on the hospital's status**.  
<img width="617" alt="Screenshot 2024-08-20 at 12 06 31 AM" src="https://github.com/user-attachments/assets/7df9a05d-b049-4cc0-96c9-39ac7c697d8a">



## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related Tickets & Documents

_Link user story from projects.digitalaidseattle.org_

- This PR is a revision of Mayk/popup2 #12

## QA Instructions, Screenshots, Recordings
Mayk/popup2 #12 QA Instructions +
**Closed hospitals** should have only the **'Learn more' button**, while **actively funding hospitals** should have both **'Learn more' and 'Donate' buttons**.